### PR TITLE
Refactor hooks to use React Query

### DIFF
--- a/src/hooks/useClientes.ts
+++ b/src/hooks/useClientes.ts
@@ -1,19 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getClientes } from '../services/clientesService';
 import type { Cliente } from '../services/clientesService';
 
 export function useClientes() {
-  const [clientes, setClientes] = useState<Cliente[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const { data: clientes, isLoading: loading, error } = useQuery<Cliente[], Error>({
+    queryKey: ['clientes'],
+    queryFn: getClientes,
+    staleTime: 1000 * 60,
+  });
 
-  useEffect(() => {
-    setLoading(true);
-    getClientes()
-      .then(setClientes)
-      .catch(() => setError('Error al cargar clientes'))
-      .finally(() => setLoading(false));
-  }, []);
-
-  return { clientes, loading, error };
+  return {
+    clientes: clientes ?? [],
+    loading,
+    error: error ? error.message : null,
+    refetch: () => queryClient.invalidateQueries({ queryKey: ['clientes'] })
+  };
 }

--- a/src/hooks/usePedidos.ts
+++ b/src/hooks/usePedidos.ts
@@ -1,19 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getPedidos} from '../services/pedidosService';
 import type { Pedido } from '../services/pedidosService';
 
 export function usePedidos() {
-  const [pedidos, setPedidos] = useState<Pedido[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const { data: pedidos, isLoading: loading, error } = useQuery<Pedido[], Error>({
+    queryKey: ['pedidos'],
+    queryFn: getPedidos,
+    staleTime: 1000 * 60,
+  });
 
-  useEffect(() => {
-    setLoading(true);
-    getPedidos()
-      .then(setPedidos)
-      .catch(() => setError('Error al cargar pedidos'))
-      .finally(() => setLoading(false));
-  }, []);
-
-  return { pedidos, loading, error };
+  return {
+    pedidos: pedidos ?? [],
+    loading,
+    error: error ? error.message : null,
+    refetch: () => queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+  };
 }

--- a/src/hooks/useUsuarios.ts
+++ b/src/hooks/useUsuarios.ts
@@ -1,19 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getUsuarios} from '../services/usuariosService';
 import type { Usuario } from '../services/usuariosService';
 
 export function useUsuarios() {
-  const [usuarios, setUsuarios] = useState<Usuario[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const { data: usuarios, isLoading: loading, error } = useQuery<Usuario[], Error>({
+    queryKey: ['usuarios'],
+    queryFn: getUsuarios,
+    staleTime: 1000 * 60,
+  });
 
-  useEffect(() => {
-    setLoading(true);
-    getUsuarios()
-      .then(setUsuarios)
-      .catch(() => setError('Error al cargar usuarios'))
-      .finally(() => setLoading(false));
-  }, []);
-
-  return { usuarios, loading, error };
+  return {
+    usuarios: usuarios ?? [],
+    loading,
+    error: error ? error.message : null,
+    refetch: () => queryClient.invalidateQueries({ queryKey: ['usuarios'] })
+  };
 }


### PR DESCRIPTION
## Summary
- adopt `useQuery` in hooks for clientes, usuarios, pedidos and ventas

## Testing
- `npm run build` *(fails: Cannot find module 'axios' and others)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68472c7546c8832db7013e414af7abca