### PR TITLE
Fix dashboard and other pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,13 @@
         "@types/react-router-dom": "^5.3.3",
         "axios": "^1.9.0",
         "bootstrap": "^5.3.6",
+        "chart.js": "^4.4.0",
         "react": "^19.1.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.2"
+        "react-router-dom": "^7.6.2",
+        "react-toastify": "^11.0.5",
+        "recharts": "^2.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -266,6 +270,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1024,6 +1037,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1430,6 +1449,69 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -2006,6 +2088,27 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2082,6 +2185,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2100,6 +2324,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2114,6 +2344,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -2424,12 +2664,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -2787,6 +3042,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2831,7 +3095,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2934,12 +3197,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3057,6 +3338,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3200,6 +3490,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3246,6 +3553,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -3257,6 +3574,12 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3304,6 +3627,82 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/resolve-from": {
@@ -3472,6 +3871,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -3632,6 +4037,28 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "bootstrap": "^5.3.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.0",
+    "recharts": "^2.8.0",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,9 @@ import './App.css'
 import GestionArticulos from './pages/GestionArticulos';
 import GestionCategorias from './pages/GestionCategorias';
 import GestionClientes from './pages/GestionClientes';
+import Dashboard from './pages/Dashboard';
+import GestionPedidos from './pages/GestionPedidos';
+import GestionUsuarios from './pages/GestionUsuarios';
 import Sidebar from './layout/Sidebar';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -21,14 +24,14 @@ function App() {
           <div className="container-fluid bg-light min-vh-100 p-0">
             <Routes>
               {/* Dashboard principal */}
-              <Route path="/" element={<h2 className="text-center mt-5">Bienvenido al Panel de Administración</h2>} />
+              <Route path="/" element={<Dashboard />} />
               {/* Rutas ejemplo para futuras páginas */}
               <Route path="/productos" element={<GestionArticulos />} />
               <Route path="/categorias" element={<GestionCategorias />} />
               <Route path="/clientes" element={<GestionClientes />} />
               <Route path="/ventas" element={<h3>Gestión de Ventas</h3>} />
-              <Route path="/usuarios" element={<h3>Gestión de Usuarios</h3>} />
-              <Route path="/pedidos" element={<h3>Gestión de Pedidos</h3>} />
+              <Route path="/usuarios" element={<GestionUsuarios />} />
+              <Route path="/pedidos" element={<GestionPedidos />} />
               {/* Redirección para rutas no encontradas */}
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>

--- a/src/components/Estadisticas/GraficaPedidosPorEstado.tsx
+++ b/src/components/Estadisticas/GraficaPedidosPorEstado.tsx
@@ -29,7 +29,7 @@ const GraficaPedidosPorEstado: React.FC = () => {
         <ResponsiveContainer width="100%" height={260}>
           <PieChart>
             <Pie data={data} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
-              {data.map((entry, index) => (
+              {data.map((_, index) => (
                 <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
               ))}
             </Pie>

--- a/src/components/Pedidos/TablaPedidos.tsx
+++ b/src/components/Pedidos/TablaPedidos.tsx
@@ -141,7 +141,7 @@ const TablaPedidos: React.FC<TablaPedidosProps> = ({ pedidos, ventas, loading, e
             <tbody>
               {pedidos.map(pedido => (
                 <tr key={pedido._id}>
-                  <td className="fw-semibold text-dark">{getNombreCliente(pedido.cliente)}</td>
+                  <td className="fw-semibold text-dark">{getNombreCliente(pedido.usuario)}</td>
                   <td>{pedido.detalles?.length ?? 0}</td>
                   <td className="text-success fw-bold">
                     {pedido.detalles?.length === 0 ? (

--- a/src/hooks/usePedidos.ts
+++ b/src/hooks/usePedidos.ts
@@ -1,29 +1,17 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-<<<<<<< HEAD
 import { getPedidos } from '../services/pedidosService';
-=======
-import { getPedidos} from '../services/pedidosService';
->>>>>>> 3a1d551894d2cdc883f3b63b919fd3bfa122d5b3
 import type { Pedido } from '../services/pedidosService';
 
 export function usePedidos() {
   const queryClient = useQueryClient();
-<<<<<<< HEAD
   const { data: pedidos = [], isLoading: loading, error } = useQuery<Pedido[], Error>({
-=======
-  const { data: pedidos, isLoading: loading, error } = useQuery<Pedido[], Error>({
->>>>>>> 3a1d551894d2cdc883f3b63b919fd3bfa122d5b3
     queryKey: ['pedidos'],
     queryFn: getPedidos,
     staleTime: 1000 * 60,
   });
 
   return {
-<<<<<<< HEAD
     pedidos,
-=======
-    pedidos: pedidos ?? [],
->>>>>>> 3a1d551894d2cdc883f3b63b919fd3bfa122d5b3
     loading,
     error: error ? error.message : null,
     refetch: () => queryClient.invalidateQueries({ queryKey: ['pedidos'] })

--- a/src/hooks/useUsuarios.ts
+++ b/src/hooks/useUsuarios.ts
@@ -1,43 +1,5 @@
-<<<<<<< HEAD
-import { useEffect, useState } from 'react';
-import {
-  getUsuarios,
-  getUsuariosActivos,
-  getUsuariosInactivos,
-  buscarUsuariosPorNombre,
-  buscarUsuariosPorRol
-} from '../services/usuariosService';
-import type { Usuario } from '../services/usuariosService';
-
-export function useUsuarios({ tipo = 'todos', nombre = '', rol = '' }: { tipo?: 'todos' | 'activos' | 'inactivos', nombre?: string, rol?: string } = {}) {
-  const [usuarios, setUsuarios] = useState<Usuario[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    let fetchFn: Promise<Usuario[]>;
-    if (tipo === 'activos') {
-      fetchFn = getUsuariosActivos();
-    } else if (tipo === 'inactivos') {
-      fetchFn = getUsuariosInactivos();
-    } else if (nombre) {
-      fetchFn = buscarUsuariosPorNombre(nombre);
-    } else if (rol) {
-      fetchFn = buscarUsuariosPorRol(rol);
-    } else {
-      fetchFn = getUsuarios();
-    }
-    fetchFn
-      .then(setUsuarios)
-      .catch(() => setError('Error al cargar usuarios'))
-      .finally(() => setLoading(false));
-  }, [tipo, nombre, rol]);
-
-  return { usuarios, loading, error };
-=======
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getUsuarios} from '../services/usuariosService';
+import { getUsuarios } from '../services/usuariosService';
 import type { Usuario } from '../services/usuariosService';
 
 export function useUsuarios() {
@@ -54,5 +16,4 @@ export function useUsuarios() {
     error: error ? error.message : null,
     refetch: () => queryClient.invalidateQueries({ queryKey: ['usuarios'] })
   };
->>>>>>> 3a1d551894d2cdc883f3b63b919fd3bfa122d5b3
 }

--- a/src/hooks/useVentas.ts
+++ b/src/hooks/useVentas.ts
@@ -1,24 +1,10 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-<<<<<<< HEAD
-import { getVentasTotales, getResumenVentasMensual } from '../services/ventasService';
-=======
-import { getVentasUltimos7Dias, getResumenVentasMensual} from '../services/ventasService';
->>>>>>> 3a1d551894d2cdc883f3b63b919fd3bfa122d5b3
+import { getVentasUltimos7Dias, getResumenVentasMensual } from '../services/ventasService';
 import type { Venta } from '../services/ventasService';
 
 export function useVentas() {
   const queryClient = useQueryClient();
-<<<<<<< HEAD
-  const { data: ventas = [], isLoading: loading, error } = useQuery<Venta[], Error>({
-    queryKey: ['ventas'],
-    queryFn: getVentasTotales,
-    staleTime: 1000 * 60,
-  });
-  const { data: resumen, isLoading: loadingResumen, error: errorResumen } = useQuery<any, Error>({
-    queryKey: ['resumenVentas'],
-    queryFn: getResumenVentasMensual,
-=======
-  const { data, isLoading: loading, error } = useQuery<{ventas: Venta[]; resumen: any}, Error>({
+  const { data, isLoading: loading, error } = useQuery<{ ventas: Venta[]; resumen: any }, Error>({
     queryKey: ['ventas'],
     queryFn: async () => {
       const [ventasData, resumenData] = await Promise.all([
@@ -27,26 +13,14 @@ export function useVentas() {
       ]);
       return { ventas: ventasData, resumen: resumenData };
     },
->>>>>>> 3a1d551894d2cdc883f3b63b919fd3bfa122d5b3
     staleTime: 1000 * 60,
   });
 
   return {
-<<<<<<< HEAD
-    ventas,
-    resumen,
-    loading: loading || loadingResumen,
-    error: error ? error.message : errorResumen ? errorResumen.message : null,
-    refetch: () => {
-      queryClient.invalidateQueries({ queryKey: ['ventas'] });
-      queryClient.invalidateQueries({ queryKey: ['resumenVentas'] });
-    }
-=======
     ventas: data?.ventas ?? [],
     resumen: data?.resumen ?? null,
     loading,
     error: error ? error.message : null,
     refetch: () => queryClient.invalidateQueries({ queryKey: ['ventas'] })
->>>>>>> 3a1d551894d2cdc883f3b63b919fd3bfa122d5b3
   };
 }

--- a/src/pages/GestionArticulos.tsx
+++ b/src/pages/GestionArticulos.tsx
@@ -6,7 +6,6 @@ import CardArticulo from '../components/Articulos/CardArticulo/CardArticulo';
 import { useArticulos } from '../hooks/useArticulos';
 import type { Articulo } from '../services/articulosService';
 import { crearArticulo, actualizarArticulo, eliminarArticulo } from '../services/articulosService';
-import LoaderPorcentaje from '../components/LoaderPorcentaje/LoaderPorcentaje';
 
 const GestionArticulos: React.FC = () => {
   const [showForm, setShowForm] = useState(false);
@@ -19,7 +18,6 @@ const GestionArticulos: React.FC = () => {
   const [formLoading, setFormLoading] = useState(false);
   const [formPorcentaje, setFormPorcentaje] = useState(0);
   const [fade, setFade] = useState<'in' | 'out'>('in');
-  const [pendingView, setPendingView] = useState<'list' | 'cards' | null>(null);
   const { articulos = [], loading, error, refetch } = useArticulos();
 
   // Para refrescar la tabla tras crear/editar/eliminar
@@ -94,15 +92,13 @@ const GestionArticulos: React.FC = () => {
     }
   };
 
-  // Animación al cambiar de vista
+  // Cambio simple de vista
   const handleViewChange = (mode: 'list' | 'cards') => {
     if (viewMode === mode) return;
     setFade('out');
-    setPendingView(mode);
     setTimeout(() => {
       setViewMode(mode);
       setFade('in');
-      setPendingView(null);
     }, 250); // Duración del fade-out
   };
 

--- a/src/pages/GestionCategorias.tsx
+++ b/src/pages/GestionCategorias.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { TablaCategorias } from '../components/Categorias/TablaCategorias/TablaCategorias';
 import { FormCategoria } from '../components/Categorias/FormCategoria/FormCategoria';
 import { ModalEliminarCategoria } from '../components/Categorias/ModalEliminarCategoria/ModalEliminarCategoria';
-import LoaderPorcentaje from '../components/LoaderPorcentaje/LoaderPorcentaje';
 import type { Categoria } from '../services/categoriasService';
 import { crearCategoria, actualizarCategoria, eliminarCategoria } from '../services/categoriasService';
 import { useCategorias } from '../hooks/useCategorias';

--- a/src/pages/GestionUsuarios.tsx
+++ b/src/pages/GestionUsuarios.tsx
@@ -1,40 +1,12 @@
-// import React from 'react';
-// import TablaUsuarios from '../components/Usuarios/TablaUsuarios/TablaUsuarios';
-// import FormUsuario from '../components/Usuarios/FormUsuario/FormUsuario';
+import React from 'react';
 
-// const GestionUsuarios: React.FC = () => {
-//   const [modo, setModo] = React.useState<'lista' | 'crear' | 'editar'>('lista');
-//   const [usuarioEditar, setUsuarioEditar] = React.useState<string | null>(null);
+const GestionUsuarios: React.FC = () => {
+  return (
+    <div className="container-fluid py-4">
+      <h2 className="mb-4">Gestión de Usuarios</h2>
+      <p className="alert alert-info">Módulo en construcción.</p>
+    </div>
+  );
+};
 
-//   const handleCrear = () => {
-//     setUsuarioEditar(null);
-//     setModo('crear');
-//   };
-
-//   const handleEditar = (id: string) => {
-//     setUsuarioEditar(id);
-//     setModo('editar');
-//   };
-
-//   const handleVolver = () => {
-//     setModo('lista');
-//     setUsuarioEditar(null);
-//   };
-
-//   return (
-//     <div>
-//       <h1>Gestión de Usuarios</h1>
-//       {modo === 'lista' && (
-//         <>
-//           <button onClick={handleCrear} className="btn btn-primary mb-3">Crear usuario</button>
-//           <TablaUsuarios onEditar={handleEditar} />
-//         </>
-//       )}
-//       {(modo === 'crear' || modo === 'editar') && (
-//         <FormUsuario usuarioId={usuarioEditar} onVolver={handleVolver} />
-//       )}
-//     </div>
-//   );
-// };
-
-// export default GestionUsuarios;
+export default GestionUsuarios;

--- a/src/services/pedidosService.ts
+++ b/src/services/pedidosService.ts
@@ -11,6 +11,12 @@ export interface Pedido {
     cantidad: number;
     precioUnitario: number;
   }>;
+  detalles?: Array<{
+    articulo: string;
+    cantidad: number;
+    precioUnitario: number;
+    subtotal?: number;
+  }>;
   total: number;
   fechaCreacion: string;
   estado: string;
@@ -38,4 +44,9 @@ export async function actualizarPedido(id: string, data: Partial<Pedido>): Promi
 
 export async function eliminarPedido(id: string): Promise<void> {
   await axios.delete(`${API_URL}/pedidos/${id}`);
+}
+
+export async function actualizarEstadoPedido(id: string, estado: string): Promise<Pedido> {
+  const res = await axios.put(`${API_URL}/pedidos/${id}/estado`, { estado });
+  return res.data;
 }

--- a/src/services/ventasService.ts
+++ b/src/services/ventasService.ts
@@ -17,3 +17,12 @@ export async function getResumenVentasMensual(): Promise<any> {
   const res = await axios.get(`${API_URL}/sales/resumen-mensual`);
   return res.data;
 }
+
+export async function crearVentaDesdePedido(pedido: any): Promise<any> {
+  const res = await axios.post(`${API_URL}/sales/desde-pedido`, pedido);
+  return res.data;
+}
+
+export async function borrarVentaPorPedido(pedidoId: string): Promise<void> {
+  await axios.delete(`${API_URL}/sales/por-pedido/${pedidoId}`);
+}


### PR DESCRIPTION
## Summary
- resolve merge conflicts in hooks
- add missing service helpers
- update routes to show Dashboard, Pedidos, and Usuarios
- stub GestionUsuarios page
- fix lint and build errors
- add required chart and toast dependencies

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68475cdd3078832dabdd459e06965c33